### PR TITLE
Comp 12 troubleshooting actions

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -44,6 +44,6 @@ jobs:
           for FILE in Simple-In-Out*.*; do mv $FILE ${FILE%-*}.${FILE##*.};done
 
       - name: "Copy file to S3 bucket"
-        run: "aws s3 sync --delete ./latest s3://$AWS_S3_BUCKET/desktop/latest"
+        run: "aws s3 sync --acl public-read --delete ./latest s3://$AWS_S3_BUCKET/desktop/latest"
         env:
           AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}


### PR DESCRIPTION
This will set the ACL to public-read. It doesn't set the PUBLIC flag on AWS, because I'm not giving write access to it. It can still be downloaded by a regular user (tried this in a "private" browser window.)